### PR TITLE
feat(defaults): add shared org-wide configuration files

### DIFF
--- a/defaults/.hadolint.yaml
+++ b/defaults/.hadolint.yaml
@@ -1,0 +1,9 @@
+# Managed at BrainXio/.github/defaults/
+
+---
+ignored:
+  - DL3008 # Pin versions in apt-get install; we pin via digest in FROM instead
+  - DL3006 # Pin image tags in FROM; we use ARG BASE_TAG which hadolint can't resolve
+trustedRegistries:
+  - ghcr.io
+  - docker.io

--- a/defaults/.mdformat.toml
+++ b/defaults/.mdformat.toml
@@ -1,0 +1,3 @@
+# Managed at BrainXio/.github/defaults/
+
+wrap = "keep"

--- a/defaults/.prettierrc
+++ b/defaults/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/defaults/.yamllint
+++ b/defaults/.yamllint
@@ -1,0 +1,14 @@
+# Managed at BrainXio/.github/defaults/
+
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable

--- a/defaults/README.md
+++ b/defaults/README.md
@@ -1,0 +1,20 @@
+# BrainXio Shared Defaults
+
+This directory contains the canonical source of truth for organization-wide configuration files.
+
+These files are copied into each disorder-family repository (`ocd`, future `adhd`, etc.) with minimal local overrides only when necessary.
+
+## Files
+
+- `.yamllint` – YAML linting rules
+- `.hadolint.yaml` – Dockerfile linting rules
+- `.mdformat.toml` – Markdown formatting (load-bearing)
+- `.prettierrc` – JavaScript/TypeScript/etc. formatting (advisory only)
+
+## Governance
+
+- **Edit here first** for any generic change.
+- Local copies in individual repos may exist with a short header pointing back to this location.
+- Never recreate or significantly modify these files locally without checking the source of truth.
+
+See `docs/explanation/org-defaults.md` in any project repository for full usage rules.


### PR DESCRIPTION
This change establishes the central source of truth for the four generic formatting and linting configuration files used across BrainXio repositories.

### Files added
- `.yamllint`
- `.hadolint.yaml`
- `.mdformat.toml`
- `.prettierrc`

### What was done
- All files are now in `defaults/` with short "managed at" headers (where comments are supported).
- Added self-documenting `defaults/README.md` explaining purpose and governance.
- This completes the first half of the minimal defaults migration.

Future disorder-family repositories (starting with ocd) will reference these files directly, improving **consistent defaults** while preserving **minimal surface area**.

No functional changes to existing behavior.
```

**Type of change**
- [ ] Bug fix
- [x] New feature (organizational shared defaults)
- [ ] Breaking change
- [x] This change requires a documentation update (the new `defaults/README.md`)

**How Has This Been Tested?**
- Manually verified all four config files match the originals from ocd.
- Confirmed headers do not break any tool (yamllint, hadolint, mdformat, prettier).
- `defaults/README.md` renders correctly.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (via headers + README)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
