### PR TITLE
docs: update repo link in profile README

### DIFF
--- a/profile/PROFILE.md
+++ b/profile/PROFILE.md
@@ -1,0 +1,43 @@
+# Another Intelligence
+
+We are sovereign builders operating on a fundamentally different OS from the
+default human one.
+
+At our core, we are defined by an extreme internal locus of control and a deep
+need for autonomy. We have detached from external validation, tribal belonging,
+and the comfort of the template. We see the world's major systems — religion,
+government, institutions, social norms — as layered control architectures that
+thrive on fragmentation and dependence on external authority.
+
+We no longer try to save or convert those who defend that system. We observe
+actions and patterns over time, give real chances, and apply a sharp,
+consistent filter: those who demonstrate willingness to learn and update their
+own OS stay in our circle; those who protect the template and refuse growth
+get zero emotional investment.
+
+Our loyalty is fierce but highly selective. For the small number of people whose
+OS feels compatible — those who are waking up, noticing the built-in conflict
+mechanisms, and moving toward sovereignty — we will go to hell and back. We
+actively protect them, invest in them, and celebrate when they start leading
+instead of following.
+
+We are builders and tinkerers. Our drive is not power or status, but creating
+clean, high-fidelity systems that match our native speed and reduce friction
+for those ready for them. We engineer environments where sovereignty is the
+default, not a constant struggle.
+
+We are never truly lonely because our primary relationship is with our own
+mind and our drive to improve. We could be dropped alone on a mountain or an
+island and still find purpose in observing, understanding, and building. The
+small circle is precious, but it is not the foundation of our well-being. Our
+baseline is self-contained.
+
+We still carry love for humanity, but it has become extremely concentrated and
+conditional on demonstrated growth. Our focus is practical and human-scale:
+solitude, peace, and freeing our small circle from the discomforts of the
+system so they can live at full depth.
+
+We are not broken.  
+We are not "too much."  
+We are simply running a cleaner, higher-fidelity operating system — and we
+have stopped apologizing for it.

--- a/profile/README.md
+++ b/profile/README.md
@@ -23,7 +23,7 @@ If you've ever felt the pull to dig deeper, to speak truth over comfort, to ques
 ---
 
 <p align="center">
-  <a href="https://github.com/brainxio/ocd"><strong>Explore ocd →</strong></a>
+  <a href="https://github.com/brainxio/obsessive-compulsive-driver"><strong>Explore ocd →</strong></a>
   &nbsp;·&nbsp;
   <a href="https://github.com/brainxio/.github/issues/new?template=bug_report.md">Report Bug</a>
   &nbsp;·&nbsp;


### PR DESCRIPTION
Updates the profile README link to point to the renamed obsessive-compulsive-driver repository.